### PR TITLE
Issue #3: Fix test failures

### DIFF
--- a/sdks/rust/src/elem_types/kv/mod.rs
+++ b/sdks/rust/src/elem_types/kv/mod.rs
@@ -2,8 +2,8 @@ use std::{cmp, fmt};
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct KV<K, V> {
-    k: K,
-    v: V,
+    pub k: K,
+    pub v: V,
 }
 
 impl<K, V> KV<K, V>

--- a/sdks/rust/src/tests/primitives_test.rs
+++ b/sdks/rust/src/tests/primitives_test.rs
@@ -39,8 +39,6 @@ mod tests {
             .await;
     }
 
-    // TODO: Enabling these tests seem to cause random failures in other
-    // tests in this file.
     #[tokio::test]
     #[should_panic]
     // This tests that AssertEqualUnordered is actually doing its job.
@@ -54,7 +52,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     #[should_panic]
     async fn ensure_assert_fails_on_empty() {
         DirectRunner::new()

--- a/sdks/rust/src/worker/operators.rs
+++ b/sdks/rust/src/worker/operators.rs
@@ -27,6 +27,7 @@ use std::sync::{Arc, Mutex};
 use once_cell::sync::Lazy;
 use serde_json;
 
+use crate::elem_types::kv::KV;
 use crate::internals::serialize;
 use crate::internals::urns;
 use crate::proto::beam_api::fn_execution::ProcessBundleDescriptor;
@@ -500,7 +501,7 @@ impl OperatorI for GroupByKeyWithinBundleOperator {
     fn process(&self, element: &WindowedValue) {
         // TODO: assumes global window
         let untyped_value: &dyn Any = &*element.value;
-        let (key, value) = self.key_extractor.extract(untyped_value);
+        let KV { k: key, v: value } = self.key_extractor.extract(untyped_value);
         let mut grouped_values = self.grouped_values.lock().unwrap();
         if !grouped_values.contains_key(&key) {
             grouped_values.insert(key.clone(), Box::default());


### PR DESCRIPTION
- Fix GroupByKey test by using KV instead of tuple.
- Fix data race when writing to SERIALIZED_FNS.
- Enable ensure_assert_fails test which was presumably previously causing spurious failures due to data race.

Fixes #3 