### PR TITLE
Reduce use of Any

### DIFF
--- a/sdks/rust/src/transforms/create.rs
+++ b/sdks/rust/src/transforms/create.rs
@@ -23,12 +23,12 @@ use crate::{
     internals::pvalue::{PTransform, PValue},
 };
 
-pub struct Create<T> {
-    elements: Vec<T>,
+pub struct Create<Out> {
+    elements: Vec<Out>,
 }
 
-impl<T: Clone> Create<T> {
-    pub fn new(elements: &[T]) -> Self {
+impl<Out: ElemType> Create<Out> {
+    pub fn new(elements: &[Out]) -> Self {
         Self {
             elements: elements.to_vec(),
         }
@@ -39,15 +39,15 @@ impl<T: Clone> Create<T> {
 // https://github.com/rust-lang/rust/issues/35121
 pub type Never = ();
 
-impl<E: ElemType> PTransform<Never, E> for Create<E> {
-    fn expand(&self, input: &PValue<Never>) -> PValue<E> {
+impl<Out: ElemType> PTransform<Never, Out> for Create<Out> {
+    fn expand(&self, input: &PValue<Never>) -> PValue<Out> {
         let elements = self.elements.to_vec();
         // TODO: Consider reshuffling.
         input
             .clone()
             .apply(Impulse::new())
-            .apply(ParDo::from_flatmap_with_context(Box::new(
-                move |_x| -> Vec<E> { elements.to_vec() },
-            )))
+            .apply(ParDo::from_flat_map(move |_x| -> Vec<Out> {
+                elements.to_vec()
+            }))
     }
 }

--- a/sdks/rust/src/transforms/group_by_key.rs
+++ b/sdks/rust/src/transforms/group_by_key.rs
@@ -30,19 +30,17 @@ use crate::proto::beam_api::pipeline as proto_pipeline;
 
 pub struct GroupByKey<K, V> {
     payload: String,
-    phantom_k: PhantomData<K>,
-    phantom_v: PhantomData<V>,
+    phantom: PhantomData<(K, V)>,
 }
+
+pub struct KeyExtractor<V: ElemType>(PhantomData<V>);
 
 // TODO: Use coders to allow arbitrary keys.
 impl<V: ElemType> Default for GroupByKey<String, V> {
     fn default() -> Self {
         Self {
-            payload: serialize::serialize_fn::<Box<dyn serialize::KeyExtractor>>(Box::new(
-                Box::new(serialize::TypedKeyExtractor::<V>::default()),
-            )),
-            phantom_k: PhantomData,
-            phantom_v: PhantomData,
+            payload: serialize::store_key_extractor(KeyExtractor::<V>(PhantomData)),
+            phantom: PhantomData,
         }
     }
 }

--- a/sdks/rust/src/worker/mod.rs
+++ b/sdks/rust/src/worker/mod.rs
@@ -17,9 +17,10 @@
  */
 
 mod external_worker_service;
-mod operators;
+pub mod operators;
 
 pub use external_worker_service::ExternalWorkerPool;
+pub use operators::Receiver;
 pub mod sdk_worker;
 pub mod worker_main;
 


### PR DESCRIPTION
This pr is an initial suggestion, please let me know if you feel this is the right direction! Closes #4 

After having a better look at the code, and the code of the other sdks, I no longer agree with my conclusion in https://github.com/laysakura/beam/issues/4#issuecomment-1501012735 regarding `SERIALIZED_FNS` for the following reasons:

- The beam runtime expects a worker to be able to receive requests and run operators based on those requests. The content of such a request can of course not be known at compile time, so we cannot (only) use generics to abstract over the different types of operators that such a request might ask us to run. We cannot use (just) enums either, since users are expected to be able to implement custom transforms. As far as I can tell, this forces us to use trait objects (dynamic dispatch).
- There has been discussion about serializing DoFns and sending them on the wire: https://github.com/apache/beam/issues/21089#issuecomment-1374882616. This corresponds to what is done for python in
  https://github.com/apache/beam/blob/f5f7a471321c903174b452a1982c5183a79ac6bc/sdks/python/apache_beam/transforms/core.py#L1757
  and typescript in 
  https://github.com/apache/beam/blob/f5f7a471321c903174b452a1982c5183a79ac6bc/sdks/typescript/src/apache_beam/transforms/pardo.ts#L158-L161
  I wasn't able to find a the location in the java sdk where similar things happen, but based on the docs and how the DoFn class is marked Serializable, I imagine it must be the same. However, the go sdk apparently goes out of its way to only encode function name and type
  https://github.com/apache/beam/blob/f5f7a471321c903174b452a1982c5183a79ac6bc/sdks/go/pkg/beam/core/runtime/graphx/serialize.go#L212-L232
  and then uses reflection to resolve the function at runtime rather than serializing/deserializing the function itself
  https://github.com/apache/beam/blob/f5f7a471321c903174b452a1982c5183a79ac6bc/sdks/go/pkg/beam/core/runtime/symbols.go#L86-L103
  I like the idea of avoiding serialization/deserialization of the actual closures, and a simple way seems to be to just store all the closures in a static at pipeline generation time (and of course generate the pipeline both on workers and the pipeline builder), and then only serialize/derserialize the key.

What this pr holds:
- Reduce use of `Any` and `Box` and hide any use behind newtypes for some measure of type safety. In particular, `process` used to take a `WindowedValue` which would put every single input element in a box
  https://github.com/laysakura/beam/blob/f7df217e9a9c166521cbbcc5fe612ed1a6c95d4e/sdks/rust/src/worker/operators.rs#L269-L275
  This now uses `DynamicWindowedValue`
  https://github.com/dahlbaek/beam/blob/5609a5ac85f0a31a9aeaf0082b0aa7d9c5bdcd70/sdks/rust/src/worker/operators.rs#L270-L271
  which still causes dynamic dispatch to resolve the underlying type, but avoids the box.
- Removes one use of unsafe
- I made some changes to avoid returning iterators (in the internal code, not directly exposed to the end user). For example, in
  https://github.com/dahlbaek/beam/blob/5609a5ac85f0a31a9aeaf0082b0aa7d9c5bdcd70/sdks/rust/src/internals/serialize.rs#L51-L59
  I pass in receivers instead of returning an iterator. I made this choice because the type of the iterator is known inside the definition of `process_dyn`, but it is not known at the call site of `process_dyn`.

## Todo
- [ ] Code reorganization: I didn't pay much attention to code layout and liberally sprinkled `pub` in places I needed it.
- [ ] We should probably use some type of more stable key in the static maps holding dofns and key extractors. Perhaps https://doc.rust-lang.org/stable/std/any/struct.TypeId.html would be a better alternative.

## Discussion
- It seems like parts of the worker code is in a stub state
  https://github.com/laysakura/beam/blob/f7df217e9a9c166521cbbcc5fe612ed1a6c95d4e/sdks/rust/src/worker/sdk_worker.rs
  It is not entirely clear to me to what extent this part of the code base is exercised in tests, so maybe it would make sense to add a test or two before making these changes to how the internal representation of a pipeline is serialized/deserialized.