### PR TITLE
Forbid unsafe code and release mutexlock

### DIFF
--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#[forbid(unsafe_code)]
 pub mod coders;
 pub mod elem_types;
 pub mod internals;

--- a/sdks/rust/src/worker/operators.rs
+++ b/sdks/rust/src/worker/operators.rs
@@ -411,7 +411,7 @@ impl OperatorI for RecordingOperator {
     }
 
     fn process(&self, value: DynamicWindowedValue) {
-        unsafe {
+        {
             let mut log = RECORDING_OPERATOR_LOGS.lock().unwrap();
             log.push(format!(
                 "{}.process({:?})",


### PR DESCRIPTION
This fixes https://github.com/laysakura/beam/issues/17#issue-1702953569. The last PR removed the scope brackets which caused a hang because the MutexLock was not released before calling receive.

All tests pass when running with:
`$ cargo test -- --skip target/debug`