### PR TITLE
refactor: remove `Coder<type E>` association type

### DIFF
--- a/sdks/rust/src/coders/coder_resolver/mod.rs
+++ b/sdks/rust/src/coders/coder_resolver/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 /// You may use original coders by implementing the `CoderResolver` trait.
 pub trait CoderResolver {
     type E: ElemType;
-    type C: Coder<E = Self::E>;
+    type C: Coder;
 
     /// Resolve a coder from a coder URN.
     ///

--- a/sdks/rust/src/coders/mod.rs
+++ b/sdks/rust/src/coders/mod.rs
@@ -27,17 +27,6 @@ use crate::proto::beam_api::pipeline as proto_pipeline;
 use std::fmt;
 use std::io::{self, Read, Write};
 
-// TODO move
-pub trait AsAny {
-    fn as_any(&self) -> &dyn std::any::Any;
-}
-
-impl<E: ElemType> AsAny for E {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self as &dyn std::any::Any
-    }
-}
-
 /// This is the base interface for coders, which are responsible in Apache Beam to encode and decode
 /// elements of a PCollection.
 ///

--- a/sdks/rust/src/coders/rust_coders.rs
+++ b/sdks/rust/src/coders/rust_coders.rs
@@ -22,6 +22,7 @@ use std::marker::PhantomData;
 use crate::coders::standard_coders::*;
 use crate::coders::urns::*;
 use crate::coders::Coder;
+use crate::elem_types::ElemType;
 
 #[derive(Eq, PartialEq)]
 pub struct GeneralObjectCoder<T> {
@@ -29,13 +30,11 @@ pub struct GeneralObjectCoder<T> {
 }
 
 impl Coder for GeneralObjectCoder<String> {
-    type E = String;
-
     const URN: &'static str = GENERAL_OBJECT_CODER_URN;
 
     fn encode(
         &self,
-        element: String,
+        element: &dyn ElemType,
         writer: &mut dyn std::io::Write,
         context: &crate::coders::Context,
     ) -> Result<usize, std::io::Error> {
@@ -49,7 +48,7 @@ impl Coder for GeneralObjectCoder<String> {
         &self,
         reader: &mut dyn std::io::Read,
         context: &crate::coders::Context,
-    ) -> Result<String, std::io::Error> {
+    ) -> Result<Box<dyn ElemType>, std::io::Error> {
         let marker: &mut [u8; 1] = &mut [0; 1];
         reader.read_exact(marker)?;
 

--- a/sdks/rust/src/elem_types/mod.rs
+++ b/sdks/rust/src/elem_types/mod.rs
@@ -2,10 +2,13 @@ pub mod kv;
 
 use std::fmt;
 
-use crate::{coders::required_coders::Iterable, elem_types::kv::KV};
+use crate::{
+    coders::{required_coders::Iterable, AsAny},
+    elem_types::kv::KV,
+};
 
 /// Element types used in Beam pipelines (including PTransforms, PCollections, Coders, etc.)
-pub trait ElemType: Send + Sync + 'static {}
+pub trait ElemType: AsAny + Send + Sync + 'static {}
 
 impl ElemType for Vec<u8> {}
 

--- a/sdks/rust/src/elem_types/mod.rs
+++ b/sdks/rust/src/elem_types/mod.rs
@@ -1,11 +1,21 @@
 pub mod kv;
 
-use std::fmt;
+use std::{any::Any, fmt};
 
-use crate::{
-    coders::{required_coders::Iterable, AsAny},
-    elem_types::kv::KV,
-};
+use crate::{coders::required_coders::Iterable, elem_types::kv::KV};
+
+/// `&dyn ElemType` is often downcasted.
+///
+/// `AsAny` is a utility trait to make to convert `ElemType` into `Any`, in order to use `Any::downcast_ref()`.
+pub trait AsAny {
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<E: ElemType> AsAny for E {
+    fn as_any(&self) -> &dyn Any {
+        self as &dyn Any
+    }
+}
 
 /// Element types used in Beam pipelines (including PTransforms, PCollections, Coders, etc.)
 pub trait ElemType: AsAny + Send + Sync + 'static {}


### PR DESCRIPTION
Coders are used in SDK harness. SDK harness not only has concrete types of `ElemType`.

So coders should better to have `dyn& ElemType`.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
