### PR TITLE
feat: add multiplexing data channel

### DIFF
--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -14,6 +14,7 @@ version = "2.40.0"
 dependencies = [
  "async-stream 0.2.1",
  "async-trait",
+ "async_cell",
  "bytes",
  "clap",
  "ctor",
@@ -22,6 +23,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "integer-encoding",
+ "itertools",
+ "lazy_static",
  "moka",
  "once_cell",
  "prost",
@@ -120,6 +123,12 @@ dependencies = [
  "quote",
  "syn 1.0.103",
 ]
+
+[[package]]
+name = "async_cell"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "834eee9ce518130a3b4d5af09ecc43e9d6b57ee76613f227a1ddd6b77c7a62bc"
 
 [[package]]
 name = "autocfg"

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -49,6 +49,11 @@ tokio-util = "0.7.4"
 tokio-stream = "0.1"
 tonic = "0.8"
 dashmap = "5.4"
+itertools = "0.10"
+async_cell = "0.2.2"
 
 [build-dependencies]
 tonic-build = "0.8"
+
+[dev-dependencies]
+lazy_static = "1.4.0"

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -44,9 +44,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9.14"
 strum = { version = "0.24", features = ["derive"] }
-tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "sync", "time"] }
+tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "sync", "time", "net"] }
 tokio-util = "0.7.4"
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.8"
 dashmap = "5.4"
 itertools = "0.10"

--- a/sdks/rust/src/worker/data.rs
+++ b/sdks/rust/src/worker/data.rs
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use async_cell::sync::AsyncCell;
+use dashmap::DashMap;
+use itertools::Itertools;
+use tokio::sync::mpsc;
+use tokio::sync::Mutex;
+use tonic::codegen::InterceptedService;
+use tonic::transport::Channel;
+
+use super::interceptors::WorkerIdInterceptor;
+use crate::proto::{
+    fn_execution_v1, fn_execution_v1::beam_fn_data_client as beam_fn_data_client_v1,
+};
+
+type ArcAsyncCellSenderElements = Arc<AsyncCell<mpsc::UnboundedSender<fn_execution_v1::Elements>>>;
+type InstructionId = String;
+
+#[derive(Debug)]
+pub struct MultiplexingDataChannel {
+    client:
+        beam_fn_data_client_v1::BeamFnDataClient<InterceptedService<Channel, WorkerIdInterceptor>>,
+    rx: Arc<Mutex<mpsc::UnboundedReceiver<fn_execution_v1::Elements>>>,
+    tx: mpsc::UnboundedSender<fn_execution_v1::Elements>,
+    consumers: DashMap<InstructionId, ArcAsyncCellSenderElements>,
+}
+
+impl MultiplexingDataChannel {
+    pub fn try_new(id: String, data_endpoint: String) -> Result<Self, Box<dyn std::error::Error>> {
+        let channel = Channel::from_shared(data_endpoint)?.connect_lazy();
+        let client = beam_fn_data_client_v1::BeamFnDataClient::with_interceptor(
+            channel,
+            WorkerIdInterceptor::new(id),
+        );
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        Ok(Self {
+            client,
+            tx,
+            rx: Arc::new(Mutex::new(rx)),
+            consumers: DashMap::new(),
+        })
+    }
+
+    pub async fn start(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let rx = self.rx.clone();
+        let outbound = async_stream::stream! {
+            while let Some(data_res) = rx.lock().await.recv().await {
+                yield data_res
+            }
+        };
+        let response = self.client.data(outbound).await?;
+        let mut inbound = response.into_inner();
+
+        while let Some(mut elements) = inbound.message().await? {
+            // Sort (stable), group and merge Data and Timers by instruction_id into new Elements.
+            elements
+                .data
+                .sort_by(|d1, d2| d1.instruction_id.cmp(&d2.instruction_id));
+            elements
+                .timers
+                .sort_by(|t1, t2| t1.instruction_id.cmp(&t2.instruction_id));
+
+            let gd = elements
+                .data
+                .into_iter()
+                .group_by(|d| d.instruction_id.clone());
+            let gt = elements
+                .timers
+                .into_iter()
+                .group_by(|t| t.instruction_id.clone());
+
+            // Result has to be materialized because group_by is not Sync.
+            let elements = gd
+                .into_iter()
+                .merge_join_by(gt.into_iter(), |(kgd, _), (kgt, _)| kgd.cmp(kgt))
+                .map(|eob| match eob {
+                    itertools::EitherOrBoth::Both((kd, vd), (_, vt)) => (
+                        kd,
+                        fn_execution_v1::Elements {
+                            data: vd.collect_vec(),
+                            timers: vt.collect_vec(),
+                        },
+                    ),
+                    itertools::EitherOrBoth::Left((kd, vd)) => (
+                        kd,
+                        fn_execution_v1::Elements {
+                            data: vd.collect_vec(),
+                            ..Default::default()
+                        },
+                    ),
+                    itertools::EitherOrBoth::Right((kt, vt)) => (
+                        kt,
+                        fn_execution_v1::Elements {
+                            timers: vt.collect_vec(),
+                            ..Default::default()
+                        },
+                    ),
+                })
+                .collect_vec();
+
+            // Iterate over Elements and send to the consumer for instruction_id.
+            for (id, es) in elements {
+                // TODO(sjvanrossum): This reflects the Java SDK implementation, but may be improved on if:
+                // - Senders are cached by (instruction_id, transform_id) in a HashMap and discarded on is_last.
+                // - DashMap is replaced by a moka::sync::Cache configured as a simple concurrent hash map.
+                //
+                // Benchmarking required to show if this is beneficial over some additional complexity.
+                // Repeatedly accessing the DashMap should be fine for now.
+                let cell = self
+                    .consumers
+                    .entry(id.clone())
+                    .or_insert(AsyncCell::shared())
+                    .value()
+                    .clone();
+
+                _ = cell.get().await.send(es);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn stop(&self) {
+        self.rx.lock().await.close()
+    }
+
+    pub fn register_consumer(
+        &self,
+        consumer_id: InstructionId,
+        tx: mpsc::UnboundedSender<fn_execution_v1::Elements>,
+    ) {
+        self.consumers
+            .entry(consumer_id)
+            .or_insert(Arc::new(AsyncCell::new_with(tx)));
+    }
+
+    pub fn unregister_consumer(&self, consumer_id: &InstructionId) {
+        self.consumers.remove(consumer_id);
+    }
+
+    #[inline]
+    pub fn get_producer(&self) -> mpsc::UnboundedSender<fn_execution_v1::Elements> {
+        self.tx.clone()
+    }
+}

--- a/sdks/rust/src/worker/mod.rs
+++ b/sdks/rust/src/worker/mod.rs
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-pub mod data;
+pub(super) mod data;
 mod external_worker_service;
 pub mod operators;
 
@@ -44,5 +44,7 @@ pub mod test_utils {
     }
 }
 
+#[cfg(test)]
+mod data_test;
 #[cfg(test)]
 mod worker_test;

--- a/sdks/rust/src/worker/mod.rs
+++ b/sdks/rust/src/worker/mod.rs
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+pub mod data;
 mod external_worker_service;
 pub mod operators;
 

--- a/sdks/rust/src/worker/sdk_worker.rs
+++ b/sdks/rust/src/worker/sdk_worker.rs
@@ -33,6 +33,7 @@ use crate::proto::{
     fn_execution_v1::instruction_response as instruction_response_v1, pipeline_v1,
 };
 
+use crate::worker::data::MultiplexingDataChannel;
 use crate::worker::interceptors::WorkerIdInterceptor;
 use crate::worker::operators::{create_operator, Operator, OperatorContext, OperatorI, Receiver};
 
@@ -56,6 +57,7 @@ pub struct Worker {
         moka::future::Cache<BundleDescriptorId, Arc<fn_execution_v1::ProcessBundleDescriptor>>,
     _bundle_processors: DashMap<String, BundleProcessor>,
     _active_bundle_processors: DashMap<String, BundleProcessor>,
+    _data_channels: DashMap<String, MultiplexingDataChannel>,
     _options: HashMap<String, String>,
 }
 
@@ -84,6 +86,7 @@ impl Worker {
             process_bundle_descriptors: moka::future::Cache::builder().build(),
             _bundle_processors: DashMap::new(),
             _active_bundle_processors: DashMap::new(),
+            _data_channels: DashMap::new(),
             _options: HashMap::new(),
         })
     }

--- a/sdks/rust/tests/data_test.rs
+++ b/sdks/rust/tests/data_test.rs
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use async_cell::sync::AsyncCell;
+use futures::stream::StreamExt;
+use lazy_static::lazy_static;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tonic::{
+    transport::{Server},
+    Status,
+};
+
+use apache_beam::proto::fn_execution::v1::{
+    beam_fn_data_server::BeamFnDataServer,
+    elements::{Data, Timers},
+    Elements,
+};
+
+// Contains two mock BeamFnData servers, one to consume Elements and one to produce Elements.
+mod mock {
+    use std::pin::Pin;
+    use std::sync::Arc;
+
+    use async_cell::sync::AsyncCell;
+    use futures::{stream, Stream, StreamExt};
+    use tokio::sync::Mutex;
+    use tonic::{Request, Response, Status, Streaming};
+
+    use apache_beam::proto::fn_execution::v1::{beam_fn_data_server::BeamFnData, Elements};
+
+    use crate::ELEMENTS;
+
+    pub struct DataProducer {}
+
+    #[tonic::async_trait]
+    impl BeamFnData for DataProducer {
+        type DataStream =
+            Pin<Box<dyn Stream<Item = Result<Elements, tonic::Status>> + Send + 'static>>;
+
+        async fn data(
+            &self,
+            request: Request<Streaming<Elements>>,
+        ) -> Result<Response<Self::DataStream>, Status> {
+            Ok(Response::new(Box::pin(stream::iter(
+                ELEMENTS.clone().into_iter().map(Ok),
+            ))))
+        }
+    }
+
+    pub struct DataConsumer {
+        pub stream: Arc<AsyncCell<Streaming<Elements>>>,
+    }
+
+    #[tonic::async_trait]
+    impl BeamFnData for DataConsumer {
+        type DataStream =
+            Pin<Box<dyn Stream<Item = Result<Elements, tonic::Status>> + Send + 'static>>;
+
+        async fn data(
+            &self,
+            request: Request<Streaming<Elements>>,
+        ) -> Result<Response<Self::DataStream>, Status> {
+            self.stream.set(request.into_inner());
+            Ok(Response::new(Box::pin(stream::empty())))
+        }
+    }
+}
+
+lazy_static! {
+    static ref ELEMENTS: Vec<Elements> = vec![
+        Elements {
+            data: (0..=255)
+                .map(|x| Data {
+                    instruction_id: "foo".to_owned(),
+                    data: vec![x],
+                    ..Default::default()
+                })
+                .chain((0..=255).map(|x| Data {
+                    instruction_id: "bar".to_owned(),
+                    data: vec![x],
+                    ..Default::default()
+                }))
+                .collect::<Vec<_>>(),
+            timers: (0..=255)
+                .map(|x| Timers {
+                    instruction_id: "foo".to_owned(),
+                    timers: vec![x],
+                    ..Default::default()
+                })
+                .collect::<Vec<_>>(),
+        },
+        Elements {
+            timers: (0..=255)
+                .map(|x| Timers {
+                    instruction_id: "bar".to_owned(),
+                    timers: vec![x],
+                    ..Default::default()
+                })
+                .collect::<Vec<_>>(),
+            ..Default::default()
+        },
+        Elements {
+            data: (0..128)
+                .map(|x| Data {
+                    instruction_id: "baz".to_owned(),
+                    data: vec![x],
+                    ..Default::default()
+                })
+                .collect::<Vec<_>>(),
+            ..Default::default()
+        },
+        Elements {
+            data: (128..=255)
+                .map(|x| Data {
+                    instruction_id: "baz".to_owned(),
+                    data: vec![x],
+                    ..Default::default()
+                })
+                .collect::<Vec<_>>(),
+            ..Default::default()
+        },
+        Elements {
+            timers: (0..128)
+                .map(|x| Timers {
+                    instruction_id: "qux".to_owned(),
+                    timers: vec![x],
+                    ..Default::default()
+                })
+                .collect::<Vec<_>>(),
+            ..Default::default()
+        },
+        Elements {
+            timers: (128..=255)
+                .map(|x| Timers {
+                    instruction_id: "qux".to_owned(),
+                    timers: vec![x],
+                    ..Default::default()
+                })
+                .collect::<Vec<_>>(),
+            ..Default::default()
+        },
+    ];
+}
+
+// TODO(sjvanrossum): Perhaps use turmoil for these sorts of tests?
+#[tokio::test]
+async fn multiplex_to_consumers() {
+    // Spawn a producer
+    let jh = tokio::spawn(async move {
+        Server::builder()
+            .add_service(BeamFnDataServer::new(mock::DataProducer {}))
+            .serve("[::1]:50051".parse().unwrap())
+            .await
+            .unwrap();
+    });
+
+    let mut client = apache_beam::worker::data::MultiplexingDataChannel::try_new(
+        "hello_world".to_owned(),
+        "http://[::1]:50051".to_owned(),
+    )
+    .unwrap();
+
+    let (foo_tx, foo_rx) = mpsc::unbounded_channel();
+    let (bar_tx, bar_rx) = mpsc::unbounded_channel();
+    let (baz_tx, baz_rx) = mpsc::unbounded_channel();
+    let (qux_tx, qux_rx) = mpsc::unbounded_channel();
+
+    // Register consumers before starting
+    client.register_consumer("foo".to_owned(), foo_tx);
+    client.register_consumer("bar".to_owned(), bar_tx);
+    client.register_consumer("baz".to_owned(), baz_tx);
+    client.register_consumer("qux".to_owned(), qux_tx);
+
+    tokio::spawn(async move {
+        client.start().await.unwrap();
+    });
+
+    let foo_elements = UnboundedReceiverStream::from(foo_rx)
+        .collect::<Vec<_>>()
+        .await;
+    let bar_elements = UnboundedReceiverStream::from(bar_rx)
+        .collect::<Vec<_>>()
+        .await;
+    let baz_elements = UnboundedReceiverStream::from(baz_rx)
+        .collect::<Vec<_>>()
+        .await;
+    let qux_elements = UnboundedReceiverStream::from(qux_rx)
+        .collect::<Vec<_>>()
+        .await;
+
+    // Data and Timers in Elements at index 0
+    assert_eq!(foo_elements.len(), 1);
+    // Data in Elements at index 1 and Timers in Elements at index 2
+    assert_eq!(bar_elements.len(), 2);
+    // Data in Elements at index 3 and Data in Elements at index 4
+    assert_eq!(baz_elements.len(), 2);
+    // Timers in Elements at index 5 and Timers in Elements at index 6
+    assert_eq!(qux_elements.len(), 2);
+
+    // Ordering of Data and Timers within Elements must be preserved.
+    let elements = (0..=255).collect::<Vec<_>>();
+    assert_eq!(
+        elements,
+        foo_elements
+            .iter()
+            .flat_map(|e| &e.data)
+            .flat_map(|d| &d.data)
+            .cloned()
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        elements,
+        foo_elements
+            .iter()
+            .flat_map(|e| &e.timers)
+            .flat_map(|t| &t.timers)
+            .cloned()
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        elements,
+        bar_elements
+            .iter()
+            .flat_map(|e| &e.data)
+            .flat_map(|d| &d.data)
+            .cloned()
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        elements,
+        bar_elements
+            .iter()
+            .flat_map(|e| &e.timers)
+            .flat_map(|t| &t.timers)
+            .cloned()
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        elements,
+        baz_elements
+            .iter()
+            .flat_map(|e| &e.data)
+            .flat_map(|d| &d.data)
+            .cloned()
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        elements,
+        qux_elements
+            .iter()
+            .flat_map(|e| &e.timers)
+            .flat_map(|t| &t.timers)
+            .cloned()
+            .collect::<Vec<_>>()
+    );
+
+    jh.abort();
+}
+
+// Essentially this test is somewhat pointless, since we rely on a mpsc channel.
+#[tokio::test]
+async fn multiplex_from_producers() {
+    let received = AsyncCell::shared();
+
+    // Spawn a consumer
+    let stream = received.clone();
+    let jh = tokio::spawn(async move {
+        Server::builder()
+            .add_service(BeamFnDataServer::new(mock::DataConsumer { stream }))
+            .serve("[::1]:50052".parse().unwrap())
+            .await
+            .unwrap();
+    });
+
+    let mut client = apache_beam::worker::data::MultiplexingDataChannel::try_new(
+        "hello_world".to_owned(),
+        "http://[::1]:50052".to_owned(),
+    )
+    .unwrap();
+
+    // Produce elements before starting
+    let producer = client.get_producer();
+    for es in ELEMENTS.iter() {
+        producer.send(es.clone()).unwrap();
+    }
+
+    tokio::spawn(async move {
+        client.start().await.unwrap();
+    });
+
+    let mut stream = received.take_shared().await;
+    for es in ELEMENTS.iter() {
+        assert_eq!(*es, stream.message().await.unwrap().unwrap());
+    }
+
+    jh.abort();
+}


### PR DESCRIPTION
This is a first pass at multiplexing data channels for source and sink operators.
I left a few TODOs to follow up on regarding:
- Benchmarking DashMap against Moka or combining that with a simple hash map local to the multiplexer which retrieves from the concurrent map and stores the receiver based on (InstructionId, TransformId) pairs and evicting them when their last data/timers has been observed.
- Using [turmoil](https://github.com/tokio-rs/turmoil) to simulate client and server environments in tests.

Additionally (not marked TODO), the mpsc channel is unbounded and that's fine for now since nothing's hooked up to it, so it's a little fuzzy to define a limit for a bounded channel.
